### PR TITLE
Crm 533 - linking problem in filemanager

### DIFF
--- a/src/js/filemanager.js
+++ b/src/js/filemanager.js
@@ -1005,7 +1005,7 @@ $.richFilemanagerPlugin = function(element, pluginOptions)
 						return (fullexpandedFolder.indexOf(node.id) === 0);
 					}, parentNode);
 
-					if (node) {
+					if (node && node.id !== parentNode.id) {
                         config.filetree.expandSpeed = 10;
                         tree_model.loadDataNode(node, false, true);
 					} else {


### PR DESCRIPTION
Coś się nie wiedzieć czemu zepsuło i bierzący node zaczął się pojawiać w liście potomnych nodów; w konsekwencji funkcja ładowania zawartości była wywoływana w kółko. Ten dodatkowy warunek do ifa rozwiązuje problem.
Myślę, że z uwagi na nadchodzącą migrację do nowego CRMa, gdzie filemanager jest napisany od 0 w Vue, nie ma sensu tracić czasu na jakąś głębszą analizę problemu...